### PR TITLE
Scaffold of servant server with persistent DB connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 stock-data-server.cabal
+*.sqlite3
 *~

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,9 +1,16 @@
 module Main where
 
-import           Controller.StockServer   ( app )
-import           Network.Wai.Handler.Warp ( run )
+import           Controller.StockServer   (app)
+import           Network.Wai.Handler.Warp (defaultSettings, runSettings,
+                                           setBeforeMainLoop, setPort)
+import           System.IO                (hPutStrLn, stderr)
 
 main :: IO ()
 main = do
-  putStrLn "Hello, I'm Stock API server"
-  run 8080 app
+  let port = 8080
+      settings =
+        setPort port $
+        setBeforeMainLoop
+          (hPutStrLn stderr ("Listening on port" ++ show port ++ "..."))
+          defaultSettings
+  runSettings settings =<< app

--- a/src/Config/Config.hs
+++ b/src/Config/Config.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Config.Config
+  ( _database_
+  ) where
+
+{-
+ - database
+ -}
+_database_ = "stock-data-server-dev.sqlite3"

--- a/src/Controller/StockServer.hs
+++ b/src/Controller/StockServer.hs
@@ -7,10 +7,10 @@ module Controller.StockServer
   ) where
 
 -- TODO: Do NOT import Config here!! Config should be imported only in Main.
--- TODO: Do NOT imort the Periferal modules here!! Define type class of DataStore to prevent the dependency to Periferal modules
+-- TODO: Do NOT imort the Peripheral modules here!! Define type class of DataStore to prevent the dependency to Peripheral modules
 import           Config.Config           (_database_)
 import           Controller.StockStorage (dummyStock)
-import           Periferal.DataStore     (ConnPool, doMigration, mkPool)
+import           Peripheral.DataStore    (ConnPool, doMigration, mkPool)
 import           Servant
 import           Usecase.StockOperator   (Condition, Stock, StockId,
                                           StockStorable (..))

--- a/src/Controller/StockServer.hs
+++ b/src/Controller/StockServer.hs
@@ -6,10 +6,16 @@ module Controller.StockServer
   ( app
   ) where
 
-import           Controller.StockStorage ( dummyStock )
+-- TODO: Do NOT import Config here!! Config should be imported only in Main.
+-- TODO: Do NOT imort the Periferal modules here!! Define type class of DataStore to prevent the dependency to Periferal modules
+import           Config.Config           (_database_)
+import           Controller.StockStorage (dummyStock)
+import           Periferal.DataStore     (ConnPool, doMigration, mkPool)
 import           Servant
-import           Usecase.StockOperator   ( Condition, Stock, StockId, StockStorable (..) )
+import           Usecase.StockOperator   (Condition, Stock, StockId,
+                                          StockStorable (..))
 
+--class PersistentDataStore pool where
 type StockAPI
    = Get '[ JSON] String -- for test
       :<|> ReqBody '[ JSON] Stock :> Post '[ JSON] String -- add stock data
@@ -22,8 +28,8 @@ type StockAPI
 stockAPI :: Proxy StockAPI
 stockAPI = Proxy
 
-stockServer :: Server StockAPI
-stockServer = testGet :<|> addStock :<|> stockOperations
+stockServer :: ConnPool -> Server StockAPI
+stockServer pool = testGet :<|> addStock :<|> stockOperations
   where
     testGet :: Handler String
     testGet = return "Hi, I'm Stock API server."
@@ -43,5 +49,12 @@ stockServer = testGet :<|> addStock :<|> stockOperations
         deleteStock :: StockId -> Handler String
         deleteStock stockId = return "Cannot detele Stock, please implement me!"
 
-app :: Application
-app = serve stockAPI stockServer
+server :: IO (Server StockAPI)
+server = do
+  pool <- mkPool _database_
+  doMigration pool
+  let server' = stockServer pool
+  return server'
+
+app :: IO Application
+app = serve stockAPI <$> server

--- a/src/Periferal/DataStore.hs
+++ b/src/Periferal/DataStore.hs
@@ -1,0 +1,16 @@
+module Periferal.DataStore where
+
+import           Control.Monad.Logger    (runStderrLoggingT)
+import           Data.String.Conversions (cs)
+import           Database.Persist.Sql
+import           Database.Persist.Sqlite
+
+import           Controller.StockModel   (migrateAll)
+
+type ConnPool = ConnectionPool
+
+mkPool :: FilePath -> IO ConnPool
+mkPool filePath = runStderrLoggingT $ createSqlitePool (cs filePath) 5
+
+doMigration :: ConnPool -> IO ()
+doMigration = runSqlPool (runMigration migrateAll)

--- a/src/Peripheral/DataStore.hs
+++ b/src/Peripheral/DataStore.hs
@@ -1,4 +1,4 @@
-module Periferal.DataStore where
+module Peripheral.DataStore where
 
 import           Control.Monad.Logger    (runStderrLoggingT)
 import           Data.String.Conversions (cs)


### PR DESCRIPTION
# Related issues and pull requests
- #8 

# Achievements
As the title says.

# Technical description
- Integrated persistent using sqlite with servant server.
- Uses db settings and connections as `ConnPool`
- The db state is initialized when `app` is called.

# Notes
- Todo: remove import of `Config.Cofig` in Controller.StockServer.hs. Config should be imported only in Main.
- Todo: remove import of `Periferal.DataStore` in Controller.StockServer.hs. Define type class of DataStore to prevent the dependency to Periferal modules.
- Note: Implemented just a scaffold of using db in this pull request. Initialized pool is not used at all yet.